### PR TITLE
Move lodash to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,10 +20,8 @@
   ],
   "author": "Harry Wolff",
   "license": "MIT",
-  "devDependencies": {
-    "lodash": "^2.4.1"
-  },
   "dependencies": {
+    "lodash": "^2.4.1",
     "yargs": "^1.3.2"
   }
 }


### PR DESCRIPTION
Tried to install using `npm` but couldn't run it since lodash was missing:

``` shell
❯  ~  ghost-to-md
module.js:341
    throw err;
    ^

Error: Cannot find module 'lodash'
    at Function.Module._resolveFilename (module.js:339:15)
    at Function.Module._load (module.js:290:25)
    at Module.require (module.js:367:17)
    at require (internal/module.js:16:19)
    at Object.<anonymous> (/Users/jonas/.npm-packages/lib/node_modules/ghost-to-md/index.js:5:9)
    at Module._compile (module.js:413:34)
    at Object.Module._extensions..js (module.js:422:10)
    at Module.load (module.js:357:32)
    at Function.Module._load (module.js:314:12)
    at Function.Module.runMain (module.js:447:10)
```

This PR moves lodash from `devDependencies` to `dependencies` so npm makes sure to install that as well.
